### PR TITLE
hexdump prerequisite

### DIFF
--- a/for-developers.html
+++ b/for-developers.html
@@ -65,7 +65,7 @@
 
 					<h3>Obtaining and building the code</h3>
 					<p>Make sure that you have all prerequisites installed. On Ubuntu / Debian / Raspian use:</p>
-					<p>$ <mark>sudo apt-get install build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev libcurl4-gnutls-dev libgphoto2-dev libz-dev git curl patchelf</mark></p>
+					<p>$ <mark>sudo apt-get install build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev libcurl4-gnutls-dev libgphoto2-dev libz-dev git curl patchelf bsdmainutils</mark></p>
 					<p>It is advised to remove libraw1394-dev as the build may fail if it is installed</p>
 					<p>$ <mark>sudo apt-get remove libraw1394-dev</mark></p>
 					<p>On macOS install XCode and download and build autoconf, automake and libtool (use tools/cltools.sh script).</p>


### PR DESCRIPTION
Build is using `hexdump` but instructions are missing `bsdmainutils` prerequisite.